### PR TITLE
feat: Update ArrivalController to use arrival_time instead of arrival…

### DIFF
--- a/app/Http/Controllers/ArrivalController.php
+++ b/app/Http/Controllers/ArrivalController.php
@@ -64,7 +64,7 @@ class ArrivalController extends Controller
                     $arrivalCandidate->arrival_id = $arrival->id;
                     $arrivalCandidate->status_arrival_id = 1;
                     $arrivalCandidate->status_description = 'Arrival created';
-                    $arrivalCandidate->status_date = $request->arrival_date;
+                    $arrivalCandidate->status_date = $request->arrival_time;
 
                     $arrivalCandidate->save();
 


### PR DESCRIPTION
…_date

This commit updates the ArrivalController to use the arrival_time field instead of the arrival_date field when saving the status_date for a new arrival candidate. This change ensures that the correct time is recorded for the arrival status and improves the accuracy of the application.