### PR TITLE
fix: Update CandidateController to handle null agent_id

### DIFF
--- a/app/Http/Controllers/CandidateController.php
+++ b/app/Http/Controllers/CandidateController.php
@@ -672,6 +672,12 @@ class CandidateController extends Controller
                 $userId = $request->user_id;
             }
 
+            if($request->agent_id === 'null'){
+                $agentId = Null;
+            } else {
+                $agentId = $request->agent_id;
+            }
+
             $person = Candidate::where('id', '=', $id)->first();
 
             $person->status_id = $request->status_id;
@@ -713,7 +719,7 @@ class CandidateController extends Controller
             $person->notes = $notes;
             $person->user_id = $userId;
             $person->case_id = $case_id;
-            $person->agent_id = $request->agent_id ?? null;
+            $person->agent_id = $agentId;
 
 
             $quartalyYear = date('Y', strtotime($request->date));


### PR DESCRIPTION
This commit updates the CandidateController.php file to handle the case when the agent_id is null. It sets the agentId variable to null if the request's agent_id is 'null', otherwise it assigns the value of the request's agent_id to the agentId variable. This change ensures that the agent_id is properly handled in the update method of the CandidateController.